### PR TITLE
Enhance athlete matching and chat flow

### DIFF
--- a/backend/src/models/Athlete.ts
+++ b/backend/src/models/Athlete.ts
@@ -5,12 +5,14 @@ export interface AthleteDocument extends Document {
   name: string;
   sport?: string;
   avatarUrl?: string;
+  achievements?: string[];
 }
 
 const AthleteSchema = new Schema<AthleteDocument>({
   name: { type: String, required: true },
   sport: { type: String },
   avatarUrl: { type: String },
+  achievements: { type: [String], default: [] },
 });
 
 export default mongoose.models.Athlete || mongoose.model<AthleteDocument>('Athlete', AthleteSchema);

--- a/backend/src/models/Match.ts
+++ b/backend/src/models/Match.ts
@@ -3,12 +3,14 @@ import mongoose, { Schema, Document } from 'mongoose';
 export interface MatchDocument extends Document {
   athleteId: mongoose.Types.ObjectId;
   recruiterId: mongoose.Types.ObjectId;
+  status: 'pending' | 'accepted' | 'declined';
   createdAt: Date;
 }
 
 const MatchSchema = new Schema<MatchDocument>({
   athleteId: { type: Schema.Types.ObjectId, required: true },
   recruiterId: { type: Schema.Types.ObjectId, required: true },
+  status: { type: String, enum: ['pending', 'accepted', 'declined'], default: 'pending' },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/backend/src/routes/athletes.ts
+++ b/backend/src/routes/athletes.ts
@@ -18,14 +18,15 @@ router.get('/:id', async (req, res) => {
 });
 
 router.put('/:id', async (req, res) => {
-  const { name, sport, avatarUrl } = req.body as {
+  const { name, sport, avatarUrl, achievements } = req.body as {
     name?: string;
     sport?: string;
     avatarUrl?: string;
+    achievements?: string[];
   };
   const athlete = await Athlete.findByIdAndUpdate(
     req.params.id,
-    { name, sport, avatarUrl },
+    { name, sport, avatarUrl, achievements },
     { new: true }
   );
   res.json(athlete);

--- a/backend/src/routes/matches.ts
+++ b/backend/src/routes/matches.ts
@@ -20,6 +20,25 @@ router.post('/', async (req, res) => {
   res.json(match);
 });
 
+router.patch('/:id', async (req, res) => {
+  const { status } = req.body as { status: 'accepted' | 'declined' };
+  const match = await Match.findByIdAndUpdate(
+    req.params.id,
+    { status },
+    { new: true }
+  );
+  if (match) {
+    try {
+      const io = getIO();
+      io.to(match.athleteId.toString()).emit('match', match);
+      io.to(match.recruiterId.toString()).emit('match', match);
+    } catch (err) {
+      console.error('Socket.io not initialized', err);
+    }
+  }
+  res.json(match);
+});
+
 router.get('/athlete/:id', async (req, res) => {
   const matches = await Match.find({ athleteId: req.params.id });
   res.json(matches);
@@ -28,6 +47,15 @@ router.get('/athlete/:id', async (req, res) => {
 router.get('/recruiter/:id', async (req, res) => {
   const matches = await Match.find({ recruiterId: req.params.id });
   res.json(matches);
+});
+
+router.get('/:id', async (req, res) => {
+  const match = await Match.findById(req.params.id);
+  if (!match) {
+    res.status(404).json({ message: 'Match not found' });
+    return;
+  }
+  res.json(match);
 });
 
 export default router;

--- a/frontend/app/athletes/profile/page.tsx
+++ b/frontend/app/athletes/profile/page.tsx
@@ -6,10 +6,15 @@ import api from '@/lib/api';
 export default function AthleteProfile() {
   const { user } = useAuth();
   const [avatarUrl, setAvatarUrl] = useState('');
+  const [achievements, setAchievements] = useState('');
 
   const save = async () => {
     if (!user) return;
-    await api.put(`/api/athletes/${user.id}`, { avatarUrl });
+    const achievementsArr = achievements
+      .split('\n')
+      .map((a) => a.trim())
+      .filter(Boolean);
+    await api.put(`/api/athletes/${user.id}`, { avatarUrl, achievements: achievementsArr });
     alert('Profile updated');
   };
 
@@ -23,6 +28,15 @@ export default function AthleteProfile() {
           className="border p-2 w-full rounded"
           value={avatarUrl}
           onChange={(e) => setAvatarUrl(e.target.value)}
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block text-sm font-medium mb-1">Achievements (one per line)</label>
+        <textarea
+          className="border p-2 w-full rounded"
+          rows={4}
+          value={achievements}
+          onChange={(e) => setAchievements(e.target.value)}
         />
       </div>
       <button


### PR DESCRIPTION
## Summary
- extend `Athlete` model with achievements
- add match status field and patch route
- show achievements on recruiter dashboard
- allow athletes to accept or decline matches
- block chat until a match is accepted

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840520eea8483319cc610332758bba8