### PR TITLE
Add essential pages and secure dashboards

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function AboutPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">About TalentScout</h1>
+      <p className="mb-4">
+        TalentScout connects athletes and recruiters through AI-powered matching,
+        real-time communication and streamlined collaboration.
+      </p>
+      <p>
+        Our mission is to make it easier for athletes to showcase their skills
+        and for recruiters to discover the perfect fit for their teams.
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/athletes/dashboard/page.tsx
+++ b/frontend/app/athletes/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { getSocket } from '@/lib/socket';
 import api from '@/lib/api';
 import { useAuth } from '@/lib/auth';
@@ -14,10 +15,15 @@ interface Match {
 
 export default function AthleteDashboard() {
   const { user } = useAuth();
+  const router = useRouter();
   const athleteId = user?.id || '';
   const [matches, setMatches] = useState<Match[]>([]);
 
   useEffect(() => {
+    if (!user) {
+      router.push('/login');
+      return;
+    }
     async function fetchMatches() {
       if (!athleteId) return;
       const res = await api.get(`/api/matches/athlete/${athleteId}`);
@@ -36,7 +42,7 @@ export default function AthleteDashboard() {
         });
       }
     });
-  }, [athleteId]);
+  }, [athleteId, user]);
 
   return (
     <div className="p-8">

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function ContactPage() {
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+      <p className="mb-4">
+        For any inquiries please reach out at{' '}
+        <a href="mailto:support@talentscout.example.com" className="text-blue-600 underline">
+          support@talentscout.example.com
+        </a>
+        .
+      </p>
+      <p>
+        You can also visit our{' '}
+        <Link href="/about" className="text-blue-600 underline">
+          About page
+        </Link>{' '}
+        to learn more about the project.
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -189,12 +189,6 @@ export default function HomePage() {
             >
               Get Started
             </Link>
-            <Link
-              href="/browse"
-              className="inline-block px-8 py-4 border border-blue-50 text-blue-50 font-semibold rounded-lg hover:bg-blue-50 hover:text-blue-700 transition"
-            >
-              Browse Athletes
-            </Link>
           </div>
         </div>
       </section>

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function PrivacyPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
+      <p className="mb-4">
+        We respect your privacy and do not collect personal data beyond what is
+        necessary for demonstration purposes.
+      </p>
+      <p>
+        Any information entered on this site is used solely to showcase the
+        functionality of the TalentScout demo.
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/recruiters/dashboard/page.tsx
+++ b/frontend/app/recruiters/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { getSocket } from '@/lib/socket';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -23,11 +24,16 @@ interface Match {
 
 export default function RecruiterDashboard() {
   const { user } = useAuth();
+  const router = useRouter();
   const recruiterId = user?.id || '';
   const [athletes, setAthletes] = useState<Athlete[]>([]);
   const [matches, setMatches] = useState<Match[]>([]);
 
   useEffect(() => {
+    if (!user) {
+      router.push('/login');
+      return;
+    }
     async function fetchAthletes() {
       const res = await api.get('/api/athletes');
       setAthletes(res.data);
@@ -45,7 +51,7 @@ export default function RecruiterDashboard() {
         });
       }
     });
-  }, [recruiterId]);
+  }, [recruiterId, user]);
 
   return (
     <div className="p-8">

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+export default function TermsPage() {
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Terms of Service</h1>
+      <p className="mb-4">
+        These terms govern the use of the TalentScout platform. By accessing the
+        site you agree to abide by all applicable rules and regulations.
+      </p>
+      <p>
+        This project is a demo and the terms presented here are for illustrative
+        purposes only.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- provide About, Contact, Terms, and Privacy pages
- remove unused Browse Athletes link from landing page
- redirect unauthenticated users from dashboards to login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405854a53c8331838c37e3183caeba