### PR TITLE
Add swiper view for recruiter dashboard

### DIFF
--- a/frontend/app/recruiters/dashboard/page.tsx
+++ b/frontend/app/recruiters/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { getSocket } from '@/lib/socket';
 import Link from 'next/link';
-import FifaPlayerCard from '@/components/FifaPlayerCard';
+import AthleteSwiper from '@/components/AthleteSwiper';
 import api from '@/lib/api';
 import { useAuth } from '@/lib/auth';
 
@@ -96,32 +96,26 @@ export default function RecruiterDashboard() {
           </Link>
         </p>
       )}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {athletes
-          .filter((a) => a.name.toLowerCase().includes(nameFilter.toLowerCase()))
-          .filter((a) =>
-            sportFilter === ''
-              ? true
-              : (a.sport || '').toLowerCase().includes(sportFilter.toLowerCase())
-          )
-          .filter((a) =>
-            achFilter === ''
-              ? true
-              : (a.achievements || [])
-                  .join(' ')
-                  .toLowerCase()
-                  .includes(achFilter.toLowerCase())
-          )
-          .map((athlete) => (
-            <FifaPlayerCard
-              key={athlete._id}
-              athlete={athlete}
-              disabled={!user?.isSubscribed}
-              onMatch={() =>
-                api.post('/api/matches', { athleteId: athlete._id, recruiterId })
-              }
-            />
-          ))}
+      <div className="flex justify-center mb-6">
+        <AthleteSwiper
+          athletes={athletes
+            .filter((a) => a.name.toLowerCase().includes(nameFilter.toLowerCase()))
+            .filter((a) =>
+              sportFilter === ''
+                ? true
+                : (a.sport || '').toLowerCase().includes(sportFilter.toLowerCase())
+            )
+            .filter((a) =>
+              achFilter === ''
+                ? true
+                : (a.achievements || [])
+                    .join(' ')
+                    .toLowerCase()
+                    .includes(achFilter.toLowerCase())
+            )}
+          disabled={!user?.isSubscribed}
+          onMatch={(id) => api.post('/api/matches', { athleteId: id, recruiterId })}
+        />
       </div>
 
       <h2 className="text-2xl font-bold mt-8 mb-2">Matches</h2>

--- a/frontend/components/AthleteSwiper.tsx
+++ b/frontend/components/AthleteSwiper.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { EffectCards } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/effect-cards';
+import FifaPlayerCard, { Athlete } from './FifaPlayerCard';
+
+interface AthleteSwiperProps {
+  athletes: Athlete[];
+  onMatch: (id: string) => void;
+  disabled?: boolean;
+}
+
+export default function AthleteSwiper({ athletes, onMatch, disabled }: AthleteSwiperProps) {
+  return (
+    <Swiper
+      modules={[EffectCards]}
+      effect="cards"
+      grabCursor
+      className="w-full max-w-md"
+    >
+      {athletes.map((athlete) => (
+        <SwiperSlide key={athlete._id} className="pb-8 flex justify-center">
+          <FifaPlayerCard
+            athlete={athlete}
+            onMatch={() => onMatch(athlete._id)}
+            disabled={disabled}
+          />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AthleteSwiper` swiper component
- show athletes in swiper on recruiter dashboard

## Testing
- `npx jest --runInBand --forceExit` *(fails: PASS backend/__tests__/matches.test.ts before aborting)*

------
https://chatgpt.com/codex/tasks/task_e_684327b8bfac8331878bcf1a31c966db