### PR TITLE
Fix server TS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,15 @@
     "jest": "^29.7.0",
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4"
+  },
+  "overrides": {
+    "@types/express": "4.17.23",
+    "@types/express-serve-static-core": "4.19.6",
+    "@types/multer": {
+      "@types/express": "4.17.23"
+    },
+    "@types/cookie-parser": {
+      "@types/express": "4.17.23"
+    }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "server",
   "version": "1.0.0",
-  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev src/index.ts",
@@ -25,6 +24,8 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20.5.9",
     "@types/supertest": "^2.0.12",
+    "@types/cors": "^2.8.19",
+    "@types/cookie-parser": "^1.4.9",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^8.14.1",
     "supertest": "^6.3.3",

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_SECRET = process.env.JWT_SECRET as string;
 if (!JWT_SECRET) {
   throw new Error('JWT_SECRET environment variable is required');
 }
@@ -16,8 +16,8 @@ export default function auth(req: AuthRequest, res: Response, next: NextFunction
     req.cookies.token;
   if (!token) return res.status(401).json({ message: 'No token' });
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as { id: string };
-    req.userId = decoded.id;
+    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload & { id?: string };
+    req.userId = decoded.id as string;
     next();
   } catch {
     res.status(401).json({ message: 'Invalid token' });


### PR DESCRIPTION
## Summary
- remove module type from server so ts-node-dev can run
- add express type overrides for Node 14
- ensure JWT middleware typing works with strict TypeScript

## Testing
- `npx tsc -p server/tsconfig.json`
- `npm run dev` *(fails: JWT_SECRET environment variable is required)*
- `npm test` *(failed to run due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee8e02b08331a8c4ea5bc3164405