### PR TITLE
Improve testability of Express server

### DIFF
--- a/BASELINE_REPORT.md
+++ b/BASELINE_REPORT.md
@@ -1,9 +1,5 @@
 ## Outdated packages for server
-
-```json
-{}
-
-```
+none
 ### server .env.example
 
 ```
@@ -18,19 +14,79 @@ MONGOMS_SYSTEM_BINARY=
 
 ```
 Error: Command failed: npm test --silent
-sh: 1: jest: not found
+FAIL __tests__/auth.test.ts (22.963 s)
+  ● auth flow › registers and logs in
+
+    Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-6.0.5.tgz", Details:
+    Status Code is 403 (MongoDB's 404)
+    This means that the requested version-platform combination doesn't exist
+    Try to use different version 'new MongoMemoryServer({ binary: { version: 'X.Y.Z' } })'
+    List of available versions can be found here: https://www.mongodb.com/download-center/community/releases/archive
+
+      at RedirectableRequest.<anonymous> (../node_modules/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts:426:17)
+      at RedirectableRequest.Object.<anonymous>.RedirectableRequest._processResponse (../node_modules/follow-redirects/index.js:409:10)
+      at ClientRequest.RedirectableRequest._onNativeResponse (../node_modules/follow-redirects/index.js:102:12)
+
+  ● auth flow › rejects invalid login
+
+    Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-6.0.5.tgz", Details:
+    Status Code is 403 (MongoDB's 404)
+    This means that the requested version-platform combination doesn't exist
+    Try to use different version 'new MongoMemoryServer({ binary: { version: 'X.Y.Z' } })'
+    List of available versions can be found here: https://www.mongodb.com/download-center/community/releases/archive
+
+      at RedirectableRequest.<anonymous> (../node_modules/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts:426:17)
+      at RedirectableRequest.Object.<anonymous>.RedirectableRequest._processResponse (../node_modules/follow-redirects/index.js:409:10)
+      at ClientRequest.RedirectableRequest._onNativeResponse (../node_modules/follow-redirects/index.js:102:12)
+
+  ● auth flow › lists talents with valid token
+
+    Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2404-6.0.5.tgz", Details:
+    Status Code is 403 (MongoDB's 404)
+    This means that the requested version-platform combination doesn't exist
+    Try to use different version 'new MongoMemoryServer({ binary: { version: 'X.Y.Z' } })'
+    List of available versions can be found here: https://www.mongodb.com/download-center/community/releases/archive
+
+      at RedirectableRequest.<anonymous> (../node_modules/mongodb-memory-server-core/src/util/MongoBinaryDownload.ts:426:17)
+      at RedirectableRequest.Object.<anonymous>.RedirectableRequest._processResponse (../node_modules/follow-redirects/index.js:409:10)
+      at ClientRequest.RedirectableRequest._onNativeResponse (../node_modules/follow-redirects/index.js:102:12)
+
+
+  ● Test suite failed to run
+
+    thrown: "Exceeded timeout of 20000 ms for a hook.
+    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
+
+      14 |     await mongoose.connect(mongo.getUri());
+      15 |   });
+    > 16 |   afterAll(async () => {
+         |   ^
+      17 |     await mongoose.disconnect();
+      18 |     await mongo.stop();
+      19 |   });
+
+      at __tests__/auth.test.ts:16:3
+      at Object.<anonymous> (__tests__/auth.test.ts:10:1)
+
+Jest: "global" coverage threshold for branches (50%) not met: 33.33%
+Jest: "global" coverage threshold for functions (50%) not met: 0%
+Test Suites: 1 failed, 1 total
+Tests:       3 failed, 3 total
+Snapshots:   0 total
+Time:        23.288 s, estimated 27 s
+Ran all test suites.
+Jest did not exit one second after the test run has completed.
+
+'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
 
 ```
 ## Outdated packages for web
-
-```json
-{}
-
-```
+none
 ### web .env.example
 
 ```
 NEXT_PUBLIC_API_URL=http://localhost:3001
+# Required for signing JWTs
 JWT_SECRET=your_jwt_secret
 
 ```
@@ -38,6 +94,14 @@ JWT_SECRET=your_jwt_secret
 
 ```
 Error: Command failed: npm test --silent
-sh: 1: jest: not found
+Error: ● Validation Error:
+
+  Test environment jest-environment-jsdom cannot be found. Make sure the testEnvironment configuration option points to an existing node module.
+
+  Configuration Documentation:
+  https://jestjs.io/docs/configuration
+
+
+As of Jest 28 "jest-environment-jsdom" is no longer shipped by default, make sure to install it separately.
 
 ```

--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -2,13 +2,15 @@ import request from 'supertest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 
+jest.setTimeout(20000);
+
 process.env.JWT_SECRET = 'testsecret';
 const app = require('../src/index').default;
 
 describe('auth flow', () => {
   let mongo: MongoMemoryServer;
   beforeAll(async () => {
-    mongo = await MongoMemoryServer.create();
+    mongo = await MongoMemoryServer.create({ binary: { version: '6.0.5' } });
     await mongoose.connect(mongo.getUri());
   });
   afterAll(async () => {
@@ -26,5 +28,23 @@ describe('auth flow', () => {
       .post('/api/auth/login')
       .send({ username: 'u', password: 'p' });
     expect(res2.body.token).toBeDefined();
+  });
+
+  it('rejects invalid login', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'bad', password: 'user' });
+    expect(res.status).toBe(401);
+  });
+
+  it('lists talents with valid token', async () => {
+    const register = await request(app)
+      .post('/api/auth/register')
+      .send({ username: 't', password: 'p', role: 'talent' });
+    const token = register.body.token;
+    const list = await request(app)
+      .get('/api/talents')
+      .set('Authorization', `Bearer ${token}`);
+    expect(list.status).toBe(200);
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,8 @@ mongoose
   .catch((err) => console.error(err));
 
 const port = process.env.PORT || 5000;
-app.listen(port, () => console.log(`Server running on ${port}`));
+if (require.main === module) {
+  app.listen(port, () => console.log(`Server running on ${port}`));
+}
 
 export default app;


### PR DESCRIPTION
## Summary
- avoid starting the Express app when imported so tests can mount the server
- add tests for invalid auth and token-protected routes
- document failing test results in `BASELINE_REPORT.md`

## Testing
- `npm test --silent --workspace=server` *(fails: Download failed for mongodb-memory-server)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f79801508331b2bf6fc34495339a