### PR TITLE
Enable frontend-only mock mode

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const u = await login(email, password);
+    const u = await login(email, password, role);
     if (u.role !== role) {
       alert('Incorrect role selected');
       return;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,18 +1,48 @@
 import axios from 'axios';
 
-const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
-});
+const useMock = !process.env.NEXT_PUBLIC_API_URL;
 
-api.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined') {
-    const stored = localStorage.getItem('auth');
-    if (stored) {
-      const { token } = JSON.parse(stored);
-      if (token) config.headers.Authorization = `Bearer ${token}`;
+let api: any;
+
+if (useMock) {
+  const mockAthletes = [
+    {
+      _id: 'a1',
+      name: 'Sample Athlete',
+      sport: 'soccer',
+      achievements: ['champion'],
+    },
+  ];
+
+  api = {
+    get: async (url: string) => {
+      if (url.startsWith('/api/athletes')) {
+        return { data: mockAthletes };
+      }
+      if (url.includes('/api/matches/')) {
+        return { data: { status: 'accepted' } };
+      }
+      return { data: [] };
+    },
+    post: async () => ({ data: {} }),
+    patch: async () => ({ data: {} }),
+    put: async () => ({ data: {} }),
+  };
+} else {
+  api = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+  });
+
+  api.interceptors.request.use((config: any) => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('auth');
+      if (stored) {
+        const { token } = JSON.parse(stored);
+        if (token) config.headers.Authorization = `Bearer ${token}`;
+      }
     }
-  }
-  return config;
-});
+    return config;
+  });
+}
 
 export default api;

--- a/frontend/lib/auth.tsx
+++ b/frontend/lib/auth.tsx
@@ -2,12 +2,19 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import axios from 'axios';
+
+// Use simple local mocks when no backend URL is provided
+const useMock = !process.env.NEXT_PUBLIC_API_URL;
 import { UserProfile } from '../../shared/src/types/user';
 
 interface AuthState {
   user: UserProfile | null;
   token: string | null;
-  login: (email: string, password: string) => Promise<UserProfile>;
+  login: (
+    email: string,
+    password: string,
+    role?: 'athlete' | 'recruiter'
+  ) => Promise<UserProfile>;
   signup: (
     name: string,
     email: string,
@@ -34,11 +41,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const login = async (email: string, password: string) => {
-    const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`, {
-      email,
-      password,
-    });
+  const login = async (
+    email: string,
+    password: string,
+    role: 'athlete' | 'recruiter' = 'athlete'
+  ) => {
+    if (useMock) {
+      const user: UserProfile = {
+        id: '1',
+        name: 'Mock User',
+        email,
+        role,
+        isVerified: true,
+        isSubscribed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      setToken('mock-token');
+      setUser(user);
+      localStorage.setItem('auth', JSON.stringify({ token: 'mock-token', user }));
+      return user;
+    }
+    const res = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`,
+      {
+        email,
+        password,
+      }
+    );
     setToken(res.data.token);
     setUser(res.data.user);
     localStorage.setItem('auth', JSON.stringify(res.data));
@@ -52,20 +82,49 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     role: 'athlete' | 'recruiter',
     sport?: string
   ) => {
-    const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/register`, {
-      name,
-      email,
-      password,
-      role,
-      sport,
-    });
+    if (useMock) {
+      const user: UserProfile = {
+        id: '1',
+        name,
+        email,
+        role,
+        isVerified: true,
+        isSubscribed: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      setToken('mock-token');
+      setUser(user);
+      localStorage.setItem('auth', JSON.stringify({ token: 'mock-token', user }));
+      return;
+    }
+    const res = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/auth/register`,
+      {
+        name,
+        email,
+        password,
+        role,
+        sport,
+      }
+    );
     setToken(res.data.token);
     setUser(res.data.user);
     localStorage.setItem('auth', JSON.stringify(res.data));
   };
 
   const subscribe = async () => {
-    await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/payments/subscribe`, { userId: user?.id });
+    if (useMock) {
+      if (user) {
+        const updated = { ...user, isSubscribed: true } as UserProfile;
+        setUser(updated);
+        localStorage.setItem('auth', JSON.stringify({ token, user: updated }));
+      }
+      return;
+    }
+    await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/payments/subscribe`, {
+      userId: user?.id,
+    });
     if (user) {
       const updated = { ...user, isSubscribed: true } as UserProfile;
       setUser(updated);

--- a/frontend/lib/socket.ts
+++ b/frontend/lib/socket.ts
@@ -1,8 +1,17 @@
 import { io, Socket } from 'socket.io-client';
 
+const useMock = !process.env.NEXT_PUBLIC_API_URL;
+
 let socket: Socket | null = null;
 
 export function getSocket(userId?: string, roomId?: string) {
+  if (useMock) {
+    // simple eventless mock
+    return {
+      on: () => {},
+      emit: () => {},
+    } as unknown as Socket;
+  }
   if (!socket) {
     socket = io(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000', {
       query: { userId, roomId },


### PR DESCRIPTION
## Summary
- add a mock flag in auth context and API helper
- allow login page to pass role into login
- stub out socket connections when no backend is defined

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849565c38a083319f6ec373f59c4937