### PR TITLE
Enhanced frontend pages

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -1,17 +1,87 @@
 'use client';
 
+import Image from 'next/image';
+
+const HERO_IMAGE = '/hero-background.jpg';
+
+interface TeamMember {
+  name: string;
+  role: string;
+  avatar: string;
+}
+
+const TEAM: TeamMember[] = [
+  { name: 'Alex Recruiter', role: 'Co-Founder', avatar: '/vercel.svg' },
+  { name: 'Jordan Scout', role: 'CTO', avatar: '/next.svg' },
+  { name: 'Taylor Athlete', role: 'Product Lead', avatar: '/globe.svg' },
+];
+
 export default function AboutPage() {
   return (
-    <div className="p-8 max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">About TalentScout</h1>
-      <p className="mb-4">
-        TalentScout connects athletes and recruiters through AI-powered matching,
-        real-time communication and streamlined collaboration.
-      </p>
-      <p>
-        Our mission is to make it easier for athletes to showcase their skills
-        and for recruiters to discover the perfect fit for their teams.
-      </p>
+    <div className="flex flex-col min-h-screen">
+      <section
+        className="relative flex-1 bg-cover bg-center"
+        style={{ backgroundImage: `url(${HERO_IMAGE})` }}
+      >
+        <div className="absolute inset-0 bg-blue-900 bg-opacity-60" />
+        <div className="relative z-10 flex flex-col items-center justify-center h-full px-4 text-center text-white">
+          <h1 className="text-4xl font-bold mb-4">About TalentScout</h1>
+          <p className="max-w-2xl">
+            TalentScout connects athletes and recruiters through AI powered
+            matching, real time communication and streamlined collaboration.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16 bg-white px-4">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold mb-6 text-center text-blue-800">
+            Our Mission
+          </h2>
+          <p className="text-center text-blue-700 mb-8">
+            We make it easier for athletes to showcase their skills and for
+            recruiters to discover the perfect fit for their teams.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {TEAM.map((member) => (
+              <div
+                key={member.name}
+                className="bg-blue-50 p-6 rounded-lg shadow text-center"
+              >
+                <Image
+                  src={member.avatar}
+                  alt={member.name}
+                  width={80}
+                  height={80}
+                  className="mx-auto mb-4"
+                />
+                <h3 className="font-semibold text-blue-800 mb-1">
+                  {member.name}
+                </h3>
+                <p className="text-sm text-blue-600">{member.role}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-blue-100 text-center">
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-3xl font-bold text-blue-700 mb-4">
+            Join our community
+          </h2>
+          <p className="mb-6 text-blue-600">
+            Whether you&apos;re an athlete looking to get noticed or a recruiter
+            seeking fresh talent, TalentScout is here to help.
+          </p>
+          <a
+            href="/signup"
+            className="inline-block px-6 py-3 bg-orange-600 text-white rounded-md hover:bg-orange-500 transition"
+          >
+            Get Started
+          </a>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,25 +1,87 @@
 'use client';
 
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+
+const Map = dynamic(() => import('../../components/Map'), { ssr: false });
 
 export default function ContactPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // eslint-disable-next-line no-alert
+    alert('Message sent! (not really, this is a demo)');
+    setName('');
+    setEmail('');
+    setMessage('');
+  };
+
   return (
-    <div className="p-8 max-w-xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
-      <p className="mb-4">
-        For any inquiries please reach out at{' '}
-        <a href="mailto:support@talentscout.example.com" className="text-blue-600 underline">
-          support@talentscout.example.com
-        </a>
-        .
-      </p>
-      <p>
-        You can also visit our{' '}
-        <Link href="/about" className="text-blue-600 underline">
-          About page
-        </Link>{' '}
-        to learn more about the project.
-      </p>
+    <div className="p-8 max-w-2xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+        <p className="mb-4">
+          For inquiries please reach out at{' '}
+          <a href="mailto:support@talentscout.example.com" className="text-blue-600 underline">
+            support@talentscout.example.com
+          </a>
+          .
+        </p>
+        <p>
+          You can also visit our{' '}
+          <Link href="/about" className="text-blue-600 underline">
+            About page
+          </Link>{' '}
+          to learn more about the project.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-blue-700 mb-1">Name</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-blue-700 mb-1">Email</label>
+          <input
+            type="email"
+            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-blue-700 mb-1">Message</label>
+          <textarea
+            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+            rows={4}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-orange-600 text-white px-6 py-2 rounded-md hover:bg-orange-500 transition"
+        >
+          Send Message
+        </button>
+      </form>
+
+      <div className="h-64 w-full rounded overflow-hidden">
+        <Map />
+      </div>
     </div>
   );
 }

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -2,16 +2,32 @@
 
 export default function PrivacyPage() {
   return (
-    <div className="p-8 max-w-3xl mx-auto">
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
       <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
-      <p className="mb-4">
-        We respect your privacy and do not collect personal data beyond what is
-        necessary for demonstration purposes.
-      </p>
-      <p>
-        Any information entered on this site is used solely to showcase the
-        functionality of the TalentScout demo.
-      </p>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Data Collection</h2>
+        <p>
+          We respect your privacy and collect only the minimal data required for
+          this demonstration. Information such as your name and email is used
+          solely for account creation and login purposes.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Use of Data</h2>
+        <p>
+          Data provided is never shared with third parties. It is stored
+          temporarily and removed on a regular basis. This project exists to
+          showcase the TalentScout concept and does not track usage beyond basic
+          analytics.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Cookies</h2>
+        <p>
+          We use cookies only for authentication. No advertising or marketing
+          cookies are stored.
+        </p>
+      </section>
     </div>
   );
 }

--- a/frontend/app/subscribe/page.tsx
+++ b/frontend/app/subscribe/page.tsx
@@ -5,17 +5,40 @@ export default function SubscribePage() {
   const { subscribe, user } = useAuth();
 
   return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Subscribe</h1>
+    <div className="p-8 max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-8 text-center">Subscribe</h1>
       {user?.isSubscribed ? (
-        <p>You are subscribed. Thank you!</p>
+        <p className="text-center">You are subscribed. Thank you!</p>
       ) : (
-        <button
-          onClick={subscribe}
-          className="px-4 py-2 bg-orange-600 text-white rounded"
-        >
-          Subscribe for $10/month
-        </button>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[
+            { tier: 'Starter', price: 'Free', desc: 'Browse limited profiles' },
+            {
+              tier: 'Pro',
+              price: '$29/mo',
+              desc: 'Unlimited matches and chat history',
+            },
+            {
+              tier: 'Elite',
+              price: '$99/mo',
+              desc: 'Priority support and advanced analytics',
+            },
+          ].map((t) => (
+            <div key={t.tier} className="bg-white p-6 rounded-lg shadow text-center">
+              <h2 className="text-xl font-semibold mb-2">{t.tier}</h2>
+              <p className="text-3xl font-bold mb-4">{t.price}</p>
+              <p className="mb-4">{t.desc}</p>
+              {t.tier !== 'Starter' && (
+                <button
+                  onClick={subscribe}
+                  className="px-4 py-2 bg-orange-600 text-white rounded hover:bg-orange-500 transition"
+                >
+                  Choose {t.tier}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -2,16 +2,30 @@
 
 export default function TermsPage() {
   return (
-    <div className="p-8 max-w-3xl mx-auto">
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
       <h1 className="text-3xl font-bold mb-4">Terms of Service</h1>
-      <p className="mb-4">
-        These terms govern the use of the TalentScout platform. By accessing the
-        site you agree to abide by all applicable rules and regulations.
-      </p>
-      <p>
-        This project is a demo and the terms presented here are for illustrative
-        purposes only.
-      </p>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Acceptance of Terms</h2>
+        <p>
+          By accessing this demo you agree to use it solely for evaluation
+          purposes. The application is provided "as is" with no warranties or
+          guarantees.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">User Conduct</h2>
+        <p>
+          Please refrain from uploading sensitive information. All content should
+          be considered public and temporary.
+        </p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Limitation of Liability</h2>
+        <p>
+          TalentScout is not liable for any damages arising from use of this
+          demonstration site.
+        </p>
+      </section>
     </div>
   );
 }

--- a/frontend/components/Map.tsx
+++ b/frontend/components/Map.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+
+const position: [number, number] = [37.7749, -122.4194];
+
+export default function Map() {
+  return (
+    <MapContainer center={position} zoom={13} scrollWheelZoom={false} style={{ height: '100%', width: '100%' }}>
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={position} icon={L.icon({ iconUrl: '/file.svg', iconSize: [32, 32] })} />
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- expand About page with hero section and team grid
- create interactive contact page with form and map
- detail privacy and terms sections
- add subscription tiers
- add reusable map component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849585b255c833191a796d4d110164d