### PR TITLE
Add leaderboard feature and progress tracking

### DIFF
--- a/recruiter-frontend/package.json
+++ b/recruiter-frontend/package.json
@@ -10,11 +10,11 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.585.0",
     "@aws-sdk/s3-request-presigner": "^3.585.0",
-    "@sendbird/uikit-react": "^3.6.0",
+    "@sendbird/uikit-react": "^3.16.9",
     "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
+    "react-router-dom": "^7.6.2",
     "react-tinder-card": "^1.4.2"
   },
   "devDependencies": {

--- a/recruiter-frontend/src/App.tsx
+++ b/recruiter-frontend/src/App.tsx
@@ -3,6 +3,7 @@ import RecruiterFeed from './pages/RecruiterFeed';
 import AthleteDashboard from './pages/AthleteDashboard';
 import ProfileEditor from './components/ProfileEditor';
 import ChatWindow from './components/ChatWindow';
+import Leaderboard from './pages/Leaderboard';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/dashboard" element={<AthleteDashboard />} />
         <Route path="/profile" element={<ProfileEditor />} />
         <Route path="/chat/:channelUrl" element={<ChatWindow />} />
+        <Route path="/leaderboard" element={<Leaderboard />} />
       </Routes>
     </div>
   );

--- a/recruiter-frontend/src/components/ProfileEditor.tsx
+++ b/recruiter-frontend/src/components/ProfileEditor.tsx
@@ -31,8 +31,16 @@ export default function ProfileEditor() {
     setMedia((m) => m.filter((f) => f.id !== id));
   };
 
+  const completed = [name, school, position, stats].filter(Boolean).length +
+    (media.length > 0 ? 1 : 0);
+  const progress = Math.round((completed / 5) * 100);
+
   return (
     <div className="space-y-4">
+      <div>
+        <div className="text-sm mb-1">Profile completion: {progress}%</div>
+        <progress value={progress} max={100} className="w-full h-2" />
+      </div>
       <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" className="border p-1" />
       <input value={school} onChange={(e) => setSchool(e.target.value)} placeholder="School" className="border p-1" />
       <input value={position} onChange={(e) => setPosition(e.target.value)} placeholder="Position" className="border p-1" />

--- a/recruiter-frontend/src/pages/Leaderboard.tsx
+++ b/recruiter-frontend/src/pages/Leaderboard.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import api from '../services/api';
+
+interface Entry {
+  username: string;
+  score: number;
+}
+
+export default function Leaderboard() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    api.get<Entry[]>('/api/leaderboard').then(res => setEntries(res.data));
+  }, []);
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Leaderboard</h2>
+      <ol className="space-y-2">
+        {entries.map((e, i) => (
+          <li key={e.username} className="flex justify-between bg-white p-2 rounded shadow">
+            <span>{i + 1}. {e.username}</span>
+            <span>{e.score}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/server/__tests__/leaderboard.test.ts
+++ b/server/__tests__/leaderboard.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+
+jest.mock('../src/models/User', () => {
+  const users = [
+    { username: 'alice', score: 5, role: 'talent' },
+    { username: 'bob', score: 10, role: 'talent' },
+    { username: 'carol', score: 7, role: 'talent' }
+  ];
+  return {
+    __esModule: true,
+    default: {
+      find: async () => users
+    }
+  };
+});
+
+process.env.JWT_SECRET = 'testsecret';
+const app = require('../src/index').default;
+
+describe('GET /api/leaderboard', () => {
+  it('returns sorted leaderboard', async () => {
+    const res = await request(app).get('/api/leaderboard');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(3);
+    expect(res.body[0].username).toBe('bob');
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
 import authRoutes from './routes/auth';
 import talentRoutes from './routes/talents';
+import leaderboardRoutes from './routes/leaderboard';
 
 dotenv.config();
 
@@ -15,6 +16,7 @@ app.use(cookieParser());
 
 app.use('/api/auth', authRoutes);
 app.use('/api/talents', talentRoutes);
+app.use('/api/leaderboard', leaderboardRoutes);
 
 mongoose
   .connect(process.env.MONGO_URI || 'mongodb://localhost:27017/talentsite')

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -6,6 +6,7 @@ export interface IUser extends mongoose.Document {
   role: 'talent' | 'scout';
   isAthlete: boolean;
   isRecruiter: boolean;
+  score: number;
 }
 
 const UserSchema = new mongoose.Schema<IUser>({
@@ -13,7 +14,8 @@ const UserSchema = new mongoose.Schema<IUser>({
   password: { type: String, required: true },
   role: { type: String, enum: ['talent', 'scout'], required: true },
   isAthlete: Boolean,
-  isRecruiter: Boolean
+  isRecruiter: Boolean,
+  score: { type: Number, default: 0 }
 });
 
 export default mongoose.model<IUser>('User', UserSchema);

--- a/server/src/routes/leaderboard.ts
+++ b/server/src/routes/leaderboard.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import User from '../models/User';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const users = await User.find({ role: 'talent' });
+  const sorted = users
+    .map((u: any) => ({ username: u.username, score: u.score || 0 }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 10);
+  res.json(sorted);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add leaderboard API route
- update User model with score field
- add leaderboard page in recruiter app
- show profile completion progress
- register leaderboard page route
- update sendbird and react-router packages
- add tests for leaderboard route

## Testing
- `npm --workspace server test`
- `npm --workspace web test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a7e964ea88331bde34909fe710e30