### PR TITLE
Improve web front-end styling

### DIFF
--- a/web/__tests__/basic.test.tsx
+++ b/web/__tests__/basic.test.tsx
@@ -2,16 +2,15 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Home from '../pages/index';
 
-// Next.js's Link component relies on router context which isn't
-// available in Jest by default. Mock it with a simple anchor element
-// so that render() doesn't throw errors about missing context.
 jest.mock('next/link', () => {
   return ({ children, href }: any) => <a href={href}>{children}</a>;
 });
 
 describe('Home page', () => {
-  it('renders links', () => {
+  it('renders header and links', () => {
     render(<Home />);
-    expect(screen.getByText('Login')).toBeInTheDocument();
+    expect(screen.getByText('TalentScout')).toBeInTheDocument();
+    expect(screen.getAllByText('Login').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Sign Up').length).toBeGreaterThan(0);
   });
 });

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  const year = new Date().getFullYear();
+  return (
+    <>
+      <header className="header">
+        <div className="container">
+          <Link href="/" className="logo">TalentScout</Link>
+          <nav className="nav">
+            <Link href="/login">Login</Link>
+            <Link href="/signup">Sign Up</Link>
+          </nav>
+        </div>
+      </header>
+      <main className="container" style={{ flexDirection: 'column' }}>{children}</main>
+      <footer className="footer">
+        <div className="container">© {year} TalentScout</div>
+      </footer>
+    </>
+  );
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import { AuthProvider } from '../context/AuthContext';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,10 +1,17 @@
 import Link from 'next/link';
+import Layout from '../components/Layout';
+
 export default function Home() {
   return (
-    <div>
-      <Link href="/login">Login</Link>
-      <br />
-      <Link href="/signup">Sign Up</Link>
-    </div>
+    <Layout>
+      <section className="hero">
+        <h1>Welcome to TalentScout</h1>
+        <p>Connect with athletes and recruiters around the world.</p>
+        <div className="actions">
+          <Link href="/login" className="btn">Login</Link>
+          <Link href="/signup" className="btn primary">Sign Up</Link>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -1,6 +1,7 @@
 import { FormEvent } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
+import Layout from '../components/Layout';
 
 export default function Login() {
   const { setToken } = useAuth();
@@ -13,8 +14,8 @@ export default function Login() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        username: form.username.value,
-        password: form.password.value
+        username: (form as any).username.value,
+        password: (form as any).password.value
       }),
       credentials: 'include'
     });
@@ -24,10 +25,19 @@ export default function Login() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <input name="username" placeholder="username" />
-      <input name="password" type="password" placeholder="password" />
-      <button type="submit">Login</button>
-    </form>
+    <Layout>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <label>
+          Username
+          <input name="username" />
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" />
+        </label>
+        <button type="submit" className="btn primary">Login</button>
+      </form>
+    </Layout>
   );
 }

--- a/web/pages/profile.tsx
+++ b/web/pages/profile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
+import Layout from '../components/Layout';
 
 export default function Profile() {
   const { token } = useAuth();
@@ -9,7 +10,7 @@ export default function Profile() {
     async function fetchData() {
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/verify`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${token}` },
         credentials: 'include'
       });
       const data = await res.json();
@@ -18,5 +19,10 @@ export default function Profile() {
     if (token) fetchData();
   }, [token]);
 
-  return <div>{message || 'Loading...'}</div>;
+  return (
+    <Layout>
+      <h1>Profile</h1>
+      <p>{message || 'Loading...'}</p>
+    </Layout>
+  );
 }

--- a/web/pages/signup.tsx
+++ b/web/pages/signup.tsx
@@ -1,6 +1,7 @@
 import { FormEvent } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
+import Layout from '../components/Layout';
 
 export default function Signup() {
   const { setToken } = useAuth();
@@ -13,8 +14,8 @@ export default function Signup() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        username: form.username.value,
-        password: form.password.value,
+        username: (form as any).username.value,
+        password: (form as any).password.value,
         role: 'talent'
       }),
       credentials: 'include'
@@ -25,10 +26,19 @@ export default function Signup() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <input name="username" placeholder="username" />
-      <input name="password" type="password" placeholder="password" />
-      <button type="submit">Sign Up</button>
-    </form>
+    <Layout>
+      <h1>Sign Up</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <label>
+          Username
+          <input name="username" />
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" />
+        </label>
+        <button type="submit" className="btn primary">Sign Up</button>
+      </form>
+    </Layout>
   );
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,0 +1,86 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #f7fafc;
+  color: #333;
+}
+
+a {
+  color: #0070f3;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.header {
+  background-color: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.logo {
+  font-weight: bold;
+  font-size: 1.25rem;
+  margin-right: auto;
+}
+
+.nav a {
+  margin-left: 1rem;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.actions {
+  margin-top: 2rem;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid #0070f3;
+  border-radius: 4px;
+  color: #0070f3;
+}
+
+.btn.primary {
+  background-color: #0070f3;
+  color: #fff;
+  margin-left: 1rem;
+}
+
+.form {
+  max-width: 400px;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.form label {
+  margin-bottom: 1rem;
+}
+
+.form input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.footer {
+  padding: 2rem 0;
+  text-align: center;
+  color: #666;
+}


### PR DESCRIPTION
## Summary
- add global styles and a shared layout for web pages
- restyle index, login, signup, and profile pages
- include a Next.js `_app` for global CSS
- update Jest test for new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8e6789308331806e35051ba8a96b