### PR TITLE
Load Inter and Roboto Mono via next/font

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -17,5 +17,4 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,17 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AuthProvider } from "../lib/auth";
+import { Inter, Roboto_Mono } from "next/font/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-geist-sans",
+});
+
+const robotoMono = Roboto_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className="antialiased"
+        className={`${inter.variable} ${robotoMono.variable} ${inter.className} ${robotoMono.className} antialiased`}
       >
         <AuthProvider>{children}</AuthProvider>
       </body>


### PR DESCRIPTION
## Summary
- load `Inter` and `Roboto Mono` fonts in `frontend/app/layout.tsx`
- remove old `font-family` from `frontend/app/globals.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a9b22155883318139521ac0c63ae4