### PR TITLE
Add dark theme toggle to frontend

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,15 +1,24 @@
 @import "tailwindcss";
 
 :root {
-  --background: #e8f5e9; /* light green background */
+  --background: #e8f5e9; /* light theme background */
   --foreground: #171717;
+  --background-dark: #0a0a0a;
+  --foreground-dark: #ededed;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-background-dark: var(--background-dark);
+  --color-foreground-dark: var(--foreground-dark);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+}
+
+[data-theme='dark'] {
+  --background: var(--background-dark);
+  --foreground: var(--foreground-dark);
 }
 
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AuthProvider } from "../lib/auth";
+import { ThemeProvider } from "../lib/theme";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -13,11 +14,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className="antialiased"
-      >
-        <AuthProvider>{children}</AuthProvider>
+    <html lang="en" data-theme="light">
+      <body className="antialiased">
+        <AuthProvider>
+          <ThemeProvider>{children}</ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -39,9 +39,9 @@ export default function LoginPage() {
         className="relative flex-1 bg-cover bg-center"
         style={{ backgroundImage: `url(${HERO_IMAGE})` }}
       >
-        <div className="absolute inset-0 bg-green-900 bg-opacity-60" />
+        <div className="absolute inset-0 bg-green-900 bg-opacity-60 dark:bg-black dark:bg-opacity-60" />
         <div className="relative z-10 flex items-center justify-center h-full px-4">
-          <form onSubmit={handleSubmit} className="bg-white p-8 rounded-lg shadow-lg w-80">
+          <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg w-80">
           <h1 className="text-2xl font-bold text-center text-green-700 mb-6">
             Sign In
           </h1>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -198,7 +198,7 @@ export default function HomePage() {
         className="relative h-screen bg-cover bg-center"
         style={{ backgroundImage: `url(${HERO_IMAGE})` }}
       >
-        <div className="absolute inset-0 bg-green-900 bg-opacity-60"></div>
+        <div className="absolute inset-0 bg-green-900 bg-opacity-60 dark:bg-black dark:bg-opacity-60"></div>
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-center px-4">
           <motion.h1
             className="text-6xl md:text-7xl font-extrabold text-green-50 mb-4"
@@ -383,7 +383,7 @@ export default function HomePage() {
       </section>
 
       {/* FOOTER */}
-      <footer className="py-8 bg-green-900 text-green-200 text-center">
+      <footer className="py-8 bg-green-900 text-green-200 dark:bg-gray-900 dark:text-gray-300 text-center">
         <div className="max-w-4xl mx-auto px-4">
           <nav className="flex justify-center space-x-6 mb-4">
             <Link href="/about" className="hover:text-white">About</Link>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -29,9 +29,9 @@ export default function SignupPage() {
         className="relative flex-1 bg-cover bg-center"
         style={{ backgroundImage: `url(${HERO_IMAGE})` }}
       >
-        <div className="absolute inset-0 bg-green-900 bg-opacity-60" />
+        <div className="absolute inset-0 bg-green-900 bg-opacity-60 dark:bg-black dark:bg-opacity-60" />
         <div className="relative z-10 flex items-center justify-center h-full px-4">
-          <form onSubmit={handleSubmit} className="bg-white p-8 rounded-lg shadow-lg w-80">
+          <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg w-80">
             <h1 className="text-2xl font-bold text-center text-green-700 mb-6">
               Create Account
             </h1>

--- a/frontend/components/DashboardHeader.tsx
+++ b/frontend/components/DashboardHeader.tsx
@@ -1,16 +1,17 @@
 'use client';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
+import ThemeToggle from './ThemeToggle';
 
 export default function DashboardHeader() {
   const { user, logout } = useAuth();
   return (
-    <header className="bg-green-900 text-white">
+    <header className="bg-green-900 text-white dark:bg-gray-900 dark:text-gray-100">
       <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
         <Link href="/" className="font-bold text-lg">
           TalentScout
         </Link>
-        <nav className="space-x-4 text-sm">
+        <nav className="space-x-4 text-sm flex items-center">
           {user?.role === 'recruiter' && (
             <Link href="/recruiters/dashboard" className="hover:underline">
               Recruiter
@@ -21,6 +22,7 @@ export default function DashboardHeader() {
               Athlete
             </Link>
           )}
+          <ThemeToggle />
           <button onClick={logout} className="hover:underline">
             Logout
           </button>

--- a/frontend/components/FifaPlayerCard.tsx
+++ b/frontend/components/FifaPlayerCard.tsx
@@ -19,7 +19,7 @@ interface FifaPlayerCardProps {
 export default function FifaPlayerCard({ athlete, onMatch, disabled, showMatchButton = true }: FifaPlayerCardProps) {
   const rating = Math.min(99, 60 + (athlete.achievements?.length || 0) * 5);
   return (
-    <div className="relative bg-gradient-to-br from-orange-100 via-yellow-50 to-green-50 rounded-lg shadow-lg p-4 flex flex-col items-center h-full">
+    <div className="relative bg-gradient-to-br from-orange-100 via-yellow-50 to-green-50 dark:from-slate-700 dark:via-slate-800 dark:to-slate-900 rounded-lg shadow-lg p-4 flex flex-col items-center h-full">
       {athlete.avatarUrl && (
         <Image
           src={athlete.avatarUrl}
@@ -33,12 +33,12 @@ export default function FifaPlayerCard({ athlete, onMatch, disabled, showMatchBu
         {rating}
       </div>
       <div className="mt-2 text-center">
-        <h3 className="text-lg font-semibold">{athlete.name}</h3>
-        <p className="text-sm text-gray-600">{athlete.sport}</p>
+        <h3 className="text-lg font-semibold dark:text-white">{athlete.name}</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-300">{athlete.sport}</p>
         {athlete.achievements && (
           <ul className="text-xs mt-2 space-y-1">
             {athlete.achievements.slice(0, 3).map((a, idx) => (
-              <li key={idx} className="truncate">
+              <li key={idx} className="truncate dark:text-gray-300">
                 {a}
               </li>
             ))}
@@ -48,7 +48,7 @@ export default function FifaPlayerCard({ athlete, onMatch, disabled, showMatchBu
           <button
             onClick={onMatch}
             disabled={disabled}
-            className="mt-3 px-3 py-1 bg-orange-600 text-white rounded disabled:opacity-50"
+            className="mt-3 px-3 py-1 bg-orange-600 dark:bg-orange-500 text-white rounded disabled:opacity-50"
           >
             Match
           </button>

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useTheme } from '@/lib/theme';
+
+export default function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  return (
+    <button onClick={toggle} className="hover:underline">
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+}

--- a/frontend/lib/theme.tsx
+++ b/frontend/lib/theme.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeState {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeState | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    const initial = stored || "light";
+    setTheme(initial);
+    document.documentElement.setAttribute("data-theme", initial);
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,0 +1,17 @@
+export default {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--color-background)',
+        foreground: 'var(--color-foreground)',
+        'background-dark': 'var(--color-background-dark)',
+        'foreground-dark': 'var(--color-foreground-dark)'
+      }
+    }
+  },
+  darkMode: ['class', '[data-theme="dark"]']
+};


### PR DESCRIPTION
## Summary
- implement dark color vars in Tailwind theme
- provide ThemeProvider and ThemeToggle
- switch `<html>` `data-theme` via toggle in header
- style components with `dark:` classes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9b2811588331aa5da0c1797f3c0f