### PR TITLE
Fix backend build

### DIFF
--- a/backend/src/routes/athletes.ts
+++ b/backend/src/routes/athletes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request } from 'express';
 import Athlete from '../models/Athlete';
 import { authenticate } from '../middleware/auth';
 import multer from 'multer';
@@ -37,7 +37,11 @@ router.put('/:id', async (req, res) => {
 });
 
 // @ts-ignore - multer typings conflict in tests
-router.post('/:id/highlight', upload.single('video'), async (req, res) => {
+interface RequestWithFile extends Request {
+  file?: Express.Multer.File;
+}
+
+router.post('/:id/highlight', upload.single('video'), async (req: RequestWithFile, res) => {
   if (!req.file) return res.status(400).json({ message: 'No file uploaded' });
   const key = `highlights/${req.params.id}/${Date.now()}_${req.file.originalname}`;
   const url = await uploadFile(key, req.file.buffer, req.file.mimetype);

--- a/backend/src/utils/token.ts
+++ b/backend/src/utils/token.ts
@@ -1,17 +1,21 @@
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_SECRET = process.env.JWT_SECRET as string;
 if (!JWT_SECRET) {
   throw new Error('JWT_SECRET environment variable is required');
 }
 
-export function signToken(id: string) {
+export function signToken(id: string): string {
   return jwt.sign({ id }, JWT_SECRET, { expiresIn: '7d' });
 }
 
-export function verifyToken(token: string) {
+export function verifyToken(token: string): { id: string } | null {
   try {
-    return jwt.verify(token, JWT_SECRET) as { id: string };
+    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
+    if (typeof decoded === 'object' && decoded !== null && 'id' in decoded) {
+      return { id: (decoded as any).id as string };
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- augment Express request types in `athletes` route
- enforce JWT_SECRET type when signing/verifying tokens

## Testing
- `npm test`
- `npm run build` from `backend`

------
https://chatgpt.com/codex/tasks/task_e_684aab8204688331ac029d56ac267f80