### PR TITLE
Allow web package to run offline

### DIFF
--- a/BASELINE_REPORT.md
+++ b/BASELINE_REPORT.md
@@ -33,7 +33,8 @@ none
 ### web .env.example
 
 ```
-NEXT_PUBLIC_API_URL=http://localhost:3001
+# Leave NEXT_PUBLIC_API_URL empty to use built-in mock API routes
+#NEXT_PUBLIC_API_URL=http://localhost:3001
 # Required for signing JWTs
 JWT_SECRET=your_jwt_secret
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ cp .env.local.example .env.local
 npm run demo
 ```
 
+The older `web` package now also supports mock API routes. Copy the example env file, leave `NEXT_PUBLIC_API_URL` empty and run the dev server:
+
+```bash
+cd web
+cp .env.example .env
+npm run dev
+```
+
 ### Running Tests
 
 ```bash

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,4 @@
-NEXT_PUBLIC_API_URL=http://localhost:3001
+# Leave NEXT_PUBLIC_API_URL empty to use built-in mock API routes
+#NEXT_PUBLIC_API_URL=http://localhost:3001
 # Required for signing JWTs
 JWT_SECRET=your_jwt_secret

--- a/web/pages/api/auth/login.ts
+++ b/web/pages/api/auth/login.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    res.status(200).json({ token: 'mock-token' });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/web/pages/api/auth/register.ts
+++ b/web/pages/api/auth/register.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    res.status(200).json({ token: 'mock-token' });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/web/pages/api/auth/verify.ts
+++ b/web/pages/api/auth/verify.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    res.status(200).json({ message: 'Verification stub' });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -10,7 +10,8 @@ export default function Login() {
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`, {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
+    const res = await fetch(`${baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/web/pages/profile.tsx
+++ b/web/pages/profile.tsx
@@ -8,7 +8,8 @@ export default function Profile() {
 
   useEffect(() => {
     async function fetchData() {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/verify`, {
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
+      const res = await fetch(`${baseUrl}/api/auth/verify`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         credentials: 'include'

--- a/web/pages/signup.tsx
+++ b/web/pages/signup.tsx
@@ -10,7 +10,8 @@ export default function Signup() {
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/register`, {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
+    const res = await fetch(`${baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add mock API endpoints for the `web` package
- use local API when `NEXT_PUBLIC_API_URL` is unset
- document offline usage for `web` in README
- update example environment files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aad475e588331917189b5d9b38bed