### PR TITLE
Add Express backend with MongoDB and AWS S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
 coverage/
+server/.env
+server/uploads/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # TalentScout
 
-This repository mirrors the basic structure of **TalentSite**. The monorepo contains two packages:
+This repository mirrors the basic structure of **TalentSite**. The monorepo contains multiple packages:
 
 - **client/** – static HTML forms for manual testing
 - **web/** – Next.js application
+- **server/** – Express backend with MongoDB and AWS S3
 
 ## Getting Started
 
@@ -26,6 +27,7 @@ an error if this variable is missing.
 
 ```bash
 npm run dev
+npm --workspace server run dev
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "workspaces": [
     "client",
     "web",
-    "frontend"
+    "frontend",
+    "server"
   ],
   "scripts": {
     "dev": "npm --workspace web run dev",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+PORT=3001
+MONGO_URI=mongodb://localhost:27017/talentscout
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_REGION=us-east-1
+AWS_BUCKET_NAME=your_bucket

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,13 @@
+# TalentScout Backend
+
+This directory contains the Express server and API routes for TalentScout.
+
+## Development
+
+```bash
+cp .env.example .env
+npm install
+npm run dev
+```
+
+The server connects to MongoDB using the `MONGO_URI` environment variable. User avatars can be uploaded to an Amazon S3 bucket when AWS credentials and `AWS_BUCKET_NAME` are set.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "server",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "scripts": {
+    "dev": "ts-node src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "mongoose": "^8.3.0",
+    "dotenv": "^16.4.5",
+    "@aws-sdk/client-s3": "^3.531.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.2"
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import multer from 'multer';
+import { createReadStream } from 'fs';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+const PORT = process.env.PORT || 3001;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/talentscout';
+
+mongoose.connect(MONGO_URI)
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => console.error('MongoDB connection error', err));
+
+// Simple user schema
+const userSchema = new mongoose.Schema({
+  name: String,
+  email: String,
+  avatar: String,
+});
+
+const User = mongoose.model('User', userSchema);
+
+// AWS S3 setup
+const s3 = new S3Client({
+  region: process.env.AWS_REGION,
+  credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY ? {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  } : undefined,
+});
+
+const upload = multer({ dest: 'uploads/' });
+
+app.get('/api/users', async (_req, res) => {
+  const users = await User.find();
+  res.json(users);
+});
+
+app.post('/api/users', upload.single('avatar'), async (req, res) => {
+  try {
+    let avatarUrl: string | undefined;
+    if (req.file && process.env.AWS_BUCKET_NAME) {
+      const key = `avatars/${Date.now()}_${req.file.originalname}`;
+      await s3.send(new PutObjectCommand({
+        Bucket: process.env.AWS_BUCKET_NAME,
+        Key: key,
+        Body: createReadStream(req.file.path),
+      }));
+      avatarUrl = `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+    }
+    const user = new User({ name: req.body.name, email: req.body.email, avatar: avatarUrl });
+    await user.save();
+    res.status(201).json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error creating user' });
+  }
+});
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "shared" },
-    { "path": "frontend" }
+    { "path": "frontend" },
+    { "path": "server" }
   ]
 }


### PR DESCRIPTION
## Summary
- add new server workspace and Express server
- configure MongoDB connection and S3 upload
- document backend usage in README

## Testing
- `npm install --workspaces`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685906ed181c8331ad33bc62e66fddf2