### PR TITLE
Update env examples to use API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,21 @@ listens on <http://localhost:3000> while the API server runs on port 3001.
 
 
 
-To try the dashboards without a backend, use the `frontend` package which ships with mock data:
+To try the dashboards without a backend, you can run the frontends in mock mode by commenting out `NEXT_PUBLIC_API_URL` in the environment file:
 
 ```bash
 cd frontend
 cp .env.local.example .env.local
+# comment NEXT_PUBLIC_API_URL in .env.local to enable mock data
 npm run demo
 ```
 
-The older `web` package now also supports mock API routes. Copy the example env file, leave `NEXT_PUBLIC_API_URL` empty and run the dev server:
+The older `web` package also supports mock API routes. Comment the variable in `.env` before starting the dev server:
 
 ```bash
 cd web
 cp .env.example .env
+# comment NEXT_PUBLIC_API_URL in .env to enable mock data
 npm run dev
 ```
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,3 @@
 # Example environment variables for the Next.js frontend
-# Leave NEXT_PUBLIC_API_URL empty to enable mock API responses.
-#NEXT_PUBLIC_API_URL=http://localhost:3001
+# Connect to the API server by default. Comment this line to enable mock data.
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,4 +1,4 @@
-# Leave NEXT_PUBLIC_API_URL empty to use built-in mock API routes
-#NEXT_PUBLIC_API_URL=http://localhost:3001
+# API server URL. Comment out to use built-in mock API routes
+NEXT_PUBLIC_API_URL=http://localhost:3001
 # Required for signing JWTs
 JWT_SECRET=your_jwt_secret


### PR DESCRIPTION
## Summary
- default both frontends to use the API server
- explain mock mode in README

## Testing
- `npm install --workspaces`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68590ee60cf883318a92201ff9c37310