### PR TITLE
Add Stripe subscription support

### DIFF
--- a/frontend/components/DashboardHeader.tsx
+++ b/frontend/components/DashboardHeader.tsx
@@ -10,7 +10,7 @@ export default function DashboardHeader() {
         <Link href="/" className="font-bold text-lg">
           TalentScout
         </Link>
-        <nav className="space-x-4 text-sm">
+        <nav className="space-x-4 text-sm items-center flex">
           {user?.role === 'recruiter' && (
             <Link href="/recruiters/dashboard" className="hover:underline">
               Recruiter
@@ -24,6 +24,11 @@ export default function DashboardHeader() {
           <button onClick={logout} className="hover:underline">
             Logout
           </button>
+          {user && (
+            <span className="ml-4 text-xs italic">
+              {user.isSubscribed ? 'Subscribed' : 'Free tier'}
+            </span>
+          )}
         </nav>
       </div>
     </header>

--- a/frontend/lib/auth.tsx
+++ b/frontend/lib/auth.tsx
@@ -122,13 +122,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       return;
     }
-    await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/payments/subscribe`, {
+    const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/payments/subscribe`, {
       userId: user?.id,
     });
     if (user) {
       const updated = { ...user, isSubscribed: true } as UserProfile;
       setUser(updated);
       localStorage.setItem('auth', JSON.stringify({ token, user: updated }));
+    }
+    if (res.data.url) {
+      window.location.href = res.data.url as string;
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11350,6 +11350,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.2.1.tgz",
+      "integrity": "sha512-GwB1B7WSwEBzW4dilgyJruUYhbGMscrwuyHsPUmSRKrGHZ5poSh2oU9XKdii5BFVJzXHn35geRvGJ6R8bYcp8w==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -12307,7 +12327,8 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.3.0",
-        "socket.io": "^4.8.1"
+        "socket.io": "^4.8.1",
+        "stripe": "^18.2.1"
       },
       "devDependencies": {
         "ts-node": "^10.9.2",

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,3 +5,6 @@ AWS_SECRET_ACCESS_KEY=your_secret_key
 AWS_REGION=us-east-1
 AWS_BUCKET_NAME=your_bucket
 JWT_SECRET=your_jwt_secret
+STRIPE_SECRET_KEY=sk_test_your_key
+STRIPE_PRICE_ID=price_test_id
+FRONTEND_URL=http://localhost:3000

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "stripe": "^18.2.1"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary
- allow storing subscription status on users
- implement a `/api/payments/subscribe` endpoint using Stripe
- expose Stripe env vars in server example
- redirect to checkout session from the frontend
- display subscription status in dashboard header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685930afbe6c8331a42834c1528be00a