### PR TITLE
Run frontend lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Run lint
-        run: npm run lint
+        run: npm --workspace frontend run lint
       - name: Run unit tests
         run: npm test
       - name: Install Playwright browsers

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "dev": "npm --workspace web run dev",
-    "test": "node scripts/baseline.mjs"
+    "test": "node scripts/baseline.mjs",
+    "lint": "npm --workspace frontend run lint"
   },
   "overrides": {
     "@types/express": "4.17.23",


### PR DESCRIPTION
## Summary
- run frontend lint workspace in GitHub workflow
- add a root lint script pointing to the workspace

## Testing
- `npm --workspace frontend run lint` *(fails: react/no-unescaped-entities)*
- `npx playwright install --with-deps`
- `npx playwright test` *(fails: page.goto net::ERR_ABORTED)*

------
https://chatgpt.com/codex/tasks/task_e_68593f5852bc8331b72423179fc2a47a