### PR TITLE
Add backend services to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,19 @@ npm test
 This executes the baseline script which runs unit tests for each package and writes `BASELINE_REPORT.md`.
 
 ### Docker Compose
+The compose file now starts MongoDB, the API server and the Next.js frontend.
+Copy the example environment files and then launch all services:
 
-A simple `docker-compose.yml` is provided to run the Next.js app in a container.
+```bash
+cp web/.env.example web/.env
+cp server/.env.example server/.env
+docker compose up --build
+```
+
+Environment variables for MongoDB, JWT signing and optional AWS credentials are
+passed to the `server` container. The `web` service receives
+`NEXT_PUBLIC_API_URL` pointing at the API so requests from the browser resolve
+to the correct container.
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,36 @@
 version: '3'
 services:
+  mongodb:
+    image: mongo
+    volumes:
+      - mongodb_data:/data/db
+    ports:
+      - '27017:27017'
+
+  server:
+    build: ./server
+    environment:
+      MONGO_URI: mongodb://mongodb:27017/talentscout
+      JWT_SECRET: ${JWT_SECRET:-changeme}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_BUCKET_NAME: ${AWS_BUCKET_NAME:-}
+      FRONTEND_URL: http://localhost:3000
+    depends_on:
+      - mongodb
+    ports:
+      - '3001:3001'
+
   web:
     build: ./web
     environment:
-      - NEXT_PUBLIC_API_URL=
+      NEXT_PUBLIC_API_URL: http://server:3001
+      JWT_SECRET: ${JWT_SECRET:-changeme}
+    depends_on:
+      - server
     ports:
       - '3000:3000'
+
+volumes:
+  mongodb_data:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add a Dockerfile for the backend server
- extend docker-compose with MongoDB and server services
- document multi-service workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685941a758988331b24e4e388cacab9f