### PR TITLE
Improve sign up flow and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ npm install --workspaces
 Edit both `.env` files and provide values for `JWT_SECRET`, `MONGO_URI` and
 the optional AWS settings if you plan to upload avatars.
 
+### Using MongoDB Atlas
+
+You can host MongoDB in the cloud with [MongoDB Atlas](https://www.mongodb.com/cloud/atlas):
+
+1. Create a free account and deploy a **Shared** cluster.
+2. In **Database Access**, create a user and password.
+3. In **Network Access**, allow your IP address.
+4. From **Connect** → **Connect Your Application**, copy the connection string.
+5. Update `server/.env` so `MONGO_URI` points at your Atlas URL, e.g.
+
+   ```
+   MONGO_URI=mongodb+srv://user:pass@cluster0.mongodb.net/talentscout?retryWrites=true&w=majority
+   ```
+
+Start the API server after saving the file and ensure the frontend's
+`NEXT_PUBLIC_API_URL` points at the server.
+
 Use **Node.js 18** when installing dependencies. Newer Node versions may fail to
 load the `lightningcss` binary that Next.js depends on.
 If you see an error like `Cannot find module '../lightningcss.darwin-arm64.node'`,

--- a/server/src/__tests__/authRoutes.test.ts
+++ b/server/src/__tests__/authRoutes.test.ts
@@ -7,6 +7,13 @@ jest.mock('stripe', () => {
     default: jest.fn().mockImplementation(() => ({ checkout: { sessions: { create: jest.fn(() => ({ url: '' })) } } }))
   };
 });
+jest.mock('bcrypt', () => ({
+  __esModule: true,
+  default: {
+    hash: jest.fn(async () => 'hash'),
+    compare: jest.fn(async () => true)
+  }
+}));
 
 let app: any;
 let User: any;
@@ -43,16 +50,18 @@ describe('auth routes', () => {
   it('registers and logs in a user', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ name: 'Test', email: 't@example.com', password: 'pw' });
+      .send({ name: 'Test', email: 't@example.com', password: 'pw', role: 'athlete', sport: 'Soccer' });
     expect(res.status).toBe(201);
     expect(res.body.token).toBeDefined();
     expect(res.body.verifyToken).toBeDefined();
+    expect(res.body.user.role).toBe('athlete');
 
     const login = await request(app)
       .post('/api/auth/login')
       .send({ email: 't@example.com', password: 'pw' });
     expect(login.status).toBe(200);
     expect(login.body.token).toBeDefined();
+    expect(login.body.user.role).toBe('athlete');
   });
 
   it('verifies user with token', async () => {


### PR DESCRIPTION
## Summary
- support role when registering users
- record athlete profile when signing up
- update auth tests for new behavior
- explain how to use MongoDB Atlas for hosting the DB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686019522c7c83319deaa27856ed750c