### PR TITLE
Support fetching all messages

### DIFF
--- a/src/app/api/match-request/[requestId]/route.ts
+++ b/src/app/api/match-request/[requestId]/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: Promise<{ requestId: string }> }
+  { params }: { params: { requestId: string } }
 ) {
   try {
     const user = await currentUser();
@@ -19,7 +19,7 @@ export async function PATCH(
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
 
-    const { requestId } = await params;
+    const { requestId } = params;
 
     // Get the match request
     const matchRequest = await prisma.matchRequest.findUnique({

--- a/src/app/api/messages/__tests__/route.test.ts
+++ b/src/app/api/messages/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+jest.mock('@clerk/nextjs/server', () => ({ currentUser: jest.fn() }))
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    matchRequest: { findMany: jest.fn(), findUnique: jest.fn() },
+    message: { findMany: jest.fn() },
+  },
+}))
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init: { status?: number } = {}) => ({
+      json: () => Promise.resolve(data),
+      status: init.status ?? 200,
+    }),
+  },
+  NextRequest: class {},
+}))
+
+import { currentUser } from '@clerk/nextjs/server'
+import { prisma } from '@/lib/prisma'
+
+describe('GET /api/messages', () => {
+  it('returns messages for the current user when no matchRequestId is provided', async () => {
+    ;(currentUser as jest.Mock).mockResolvedValue({ id: 'user1' })
+    ;(prisma.matchRequest.findMany as jest.Mock).mockResolvedValue([{ id: 'm1' }, { id: 'm2' }])
+    ;(prisma.message.findMany as jest.Mock).mockResolvedValue([
+      { id: 'msg1', matchId: 'm1', senderId: 'user1', sender: { id: 'user1' } },
+    ])
+
+    const req = { url: 'http://localhost/api/messages' } as unknown as NextRequest
+    const res = await GET(req)
+
+    expect(prisma.matchRequest.findMany).toHaveBeenCalledWith({
+      where: { OR: [{ athleteId: 'user1' }, { recruiterId: 'user1' }], status: 'accepted' },
+      select: { id: true },
+    })
+    expect(prisma.message.findMany).toHaveBeenCalledWith({
+      where: { matchId: { in: ['m1', 'm2'] } },
+      include: { sender: true },
+      orderBy: { createdAt: 'asc' },
+    })
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual([
+      { id: 'msg1', matchId: 'm1', senderId: 'user1', sender: { id: 'user1' } },
+    ])
+  })
+})

--- a/src/app/api/profile/[userId]/route.ts
+++ b/src/app/api/profile/[userId]/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
+  { params }: { params: { userId: string } }
 ) {
   try {
     const user = await currentUser();
@@ -12,7 +12,7 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { userId } = await params;
+    const { userId } = params;
 
     // Verify the user is requesting their own profile
     if (userId !== user.id) {


### PR DESCRIPTION
## Summary
- extend messages API to return all messages for the current user when no `matchRequestId` is provided
- fix Next.js dynamic route handlers to destructure `params` without awaiting a Promise
- add tests for messages API

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689671a5adb4832986eb739cc18a43dd