### PR TITLE
test: use user-event for button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@eslint/eslintrc": "^3",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -3347,6 +3348,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@eslint/eslintrc": "^3",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Button } from '../button'
 
 describe('Button', () => {
@@ -13,13 +14,13 @@ describe('Button', () => {
     expect(button).toHaveClass('custom-class')
   })
 
-  it('handles click events', () => {
+  it('handles click events', async () => {
     const handleClick = jest.fn()
     render(<Button onClick={handleClick}>Click me</Button>)
-    
+
     const button = screen.getByRole('button', { name: /click me/i })
-    button.click()
-    
+    await userEvent.click(button)
+
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
 
@@ -27,6 +28,17 @@ describe('Button', () => {
     render(<Button disabled>Click me</Button>)
     const button = screen.getByRole('button', { name: /click me/i })
     expect(button).toBeDisabled()
+  })
+
+  it('does not call onClick when disabled', async () => {
+    const handleClick = jest.fn()
+    render(
+      <Button disabled onClick={handleClick}>
+        Click me
+      </Button>
+    )
+    await userEvent.click(screen.getByRole('button', { name: /click me/i }))
+    expect(handleClick).not.toHaveBeenCalled()
   })
 
   it('renders with different variants', () => {


### PR DESCRIPTION
## Summary
- install `@testing-library/user-event`
- use `userEvent.click` for button interactions
- verify disabled buttons don't trigger `onClick`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967352be4c8329814f23dbce0a18ab