### PR TITLE
Fix match request socket events

### DIFF
--- a/src/lib/__tests__/socket.test.ts
+++ b/src/lib/__tests__/socket.test.ts
@@ -1,0 +1,50 @@
+import { socketManager } from '../socket';
+
+interface TestSocket {
+  on: jest.Mock;
+  off: jest.Mock;
+  emit: jest.Mock;
+  connected: boolean;
+}
+
+describe('socketManager match request subscriptions', () => {
+  let mockSocket: TestSocket;
+  let manager: { socket: TestSocket | null; matchRequestCallbacks: Map<string, unknown> };
+
+  beforeEach(() => {
+    mockSocket = {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+      connected: true,
+    };
+
+    manager = socketManager as unknown as {
+      socket: TestSocket | null;
+      matchRequestCallbacks: Map<string, unknown>;
+    };
+
+    // Attach the mock socket directly
+    manager.socket = mockSocket;
+  });
+
+  afterEach(() => {
+    manager.socket = null;
+    manager.matchRequestCallbacks.clear();
+  });
+
+  it('registers listener for new match requests', () => {
+    const cb = jest.fn();
+    socketManager.subscribeToMatchRequests(cb);
+    expect(mockSocket.on).toHaveBeenCalledWith('new-match-request', cb);
+    expect(manager.matchRequestCallbacks.get('new-match-request')).toBe(cb);
+  });
+
+  it('removes listener when unsubscribing', () => {
+    const cb = jest.fn();
+    socketManager.subscribeToMatchRequests(cb);
+    socketManager.unsubscribeFromMatchRequests();
+    expect(mockSocket.off).toHaveBeenCalledWith('new-match-request');
+    expect(manager.matchRequestCallbacks.size).toBe(0);
+  });
+});

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -97,15 +97,17 @@ class SocketManager {
   subscribeToMatchRequests(callback: MatchRequestCallback) {
     if (!this.socket) return;
 
-    this.socket.on('match-request', callback);
-    this.matchRequestCallbacks.set('match-request', callback);
+    // Listen for new match requests using the server's emitted event name
+    this.socket.on('new-match-request', callback);
+    this.matchRequestCallbacks.set('new-match-request', callback);
   }
 
   unsubscribeFromMatchRequests() {
     if (!this.socket) return;
 
-    this.socket.off('match-request');
-    this.matchRequestCallbacks.delete('match-request');
+    // Remove listener for new match requests
+    this.socket.off('new-match-request');
+    this.matchRequestCallbacks.delete('new-match-request');
   }
 
   sendMessage(matchId: string, message: { content: string }) {


### PR DESCRIPTION
## Summary
- align SocketManager with server's `new-match-request` event
- add tests for match request subscription and cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6c61c2648329a6806417308c7bba